### PR TITLE
Frontend Organizers Route

### DIFF
--- a/src/auth/PrivateRoute.tsx
+++ b/src/auth/PrivateRoute.tsx
@@ -39,8 +39,7 @@ const PrivateRoute: React.FC<PrivateRouteProps> = ({
   }
 
   // if admin route, redirect if not admin
-  const namespace = "https://example.com"
-  const roles = (user && user[`${namespace}/roles`]) || []
+  const roles = (user && user[`https://cruzhacks.com/roles`]) || []
   if (admin && roles.indexOf("Organizer") === -1) {
     route = ErrorView
   }

--- a/src/components/Debug/DebugBar.tsx
+++ b/src/components/Debug/DebugBar.tsx
@@ -42,7 +42,7 @@ const DebugBar: React.FC = () => {
       <NavLink exact to='/' className='link' activeClassName='active'>
         Main
       </NavLink>
-      <NavLink exact to='portal' className='link' activeClassName='active'>
+      <NavLink exact to='/portal' className='link' activeClassName='active'>
         Portal
       </NavLink>
       <div className='align-right'>{authButton}</div>

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -6,6 +6,7 @@ import HomeView from "../views/Home/index.view"
 import PortalView from "../views/Portal/index.view"
 import TeamView from "../views/Team/index.view"
 import ErrorView from "../views/Error/index.view"
+import DashboardView from "../views/Dashboard/index.view"
 
 const Routes: React.FC = () => {
   const { isLoading } = useAuth0()
@@ -20,6 +21,13 @@ const Routes: React.FC = () => {
         <Route exact path='/' component={HomeView} />
         <Route exact path='/team' component={TeamView} />
         <PrivateRoute exact path='/portal' component={PortalView} />
+
+        <PrivateRoute
+          exact
+          admin
+          path='/admin/dashboard'
+          component={DashboardView}
+        />
 
         <Route exact path='*' component={ErrorView} />
       </Switch>

--- a/src/views/Dashboard/index.test.js
+++ b/src/views/Dashboard/index.test.js
@@ -1,0 +1,11 @@
+import Enzyme, {shallow} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import DashboardView from './index.view';
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe('Testing Dashboard View', () => {
+  it('Dashboard Page renders without crashing', () => {
+    shallow(<DashboardView />);
+  });
+});

--- a/src/views/Dashboard/index.view.tsx
+++ b/src/views/Dashboard/index.view.tsx
@@ -1,0 +1,6 @@
+import * as React from "react"
+import "./index.scss"
+
+const DashboardView: React.FC = () => <>Welcome, organizer.</>
+
+export default DashboardView

--- a/src/views/Verify/index.test.js
+++ b/src/views/Verify/index.test.js
@@ -1,6 +1,6 @@
 import Enzyme, {shallow} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Verify from './index.view';
+import VerifyView from './index.view';
 import "../../__mocks__/api";
 
 jest.mock("../../utils/Api", () => jest.fn())
@@ -9,6 +9,6 @@ Enzyme.configure({ adapter: new Adapter() })
 
 describe('Testing Verify View', () => {
   it('Verify Page renders without crashing', () => {
-    shallow(<Verify />);
+    shallow(<VerifyView />);
   });
 });

--- a/src/views/Verify/index.view.tsx
+++ b/src/views/Verify/index.view.tsx
@@ -3,7 +3,7 @@ import "./index.scss"
 import { useAuth0 } from "@auth0/auth0-react"
 import ResendVerification from "../../components/ResendVerification/ResendVerification"
 
-const Verify: React.FC = () => {
+const VerifyView: React.FC = () => {
   const { user, getAccessTokenSilently } = useAuth0()
   const [token, setToken] = useState<string>("")
   const [, setError] = useState<string>("")
@@ -29,4 +29,4 @@ const Verify: React.FC = () => {
   )
 }
 
-export default Verify
+export default VerifyView


### PR DESCRIPTION
Problem
=======
Frontend organizers route [Jira C2D-43](https://cruzhacks-dev.atlassian.net/browse/C2D-43).

Solution
========
What I/we did to solve this problem
* Add `admin` prop to PrivateRoute


Change Summary:
---------------
* Added `admin` prop to PrivateRoute so that we can define routes that only people with the organizer role can access.
* Added a test Dashboard view, also renamed `Verify` view to `VerifyView`.

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  