### PR TITLE
Update responsiveness.screen() mixin

### DIFF
--- a/src/stylesheets/_responsiveness.scss
+++ b/src/stylesheets/_responsiveness.scss
@@ -1,72 +1,58 @@
-@mixin screen($breakpoint) {
-  @if ($breakpoint == smallest) {
-    @media (max-width: 349px) {
-      @content;
-    }
-  }
+/**
+Sample usage::
+   @use "~stylesheets/responsiveness"
+   @include responsiveness.screen(smallest) {
+   }
 
-  @if ($breakpoint == phone) {
-    @media (min-width: 350px) and (max-width: 499px) {
-      @content;
+   @include responsiveness.screen(phone, tablet, large-tablet) {
+   }
+ */
+@mixin screen($breakpoints...) {
+  @each $breakpoint in $breakpoints {
+    @if ($breakpoint == smallest) {
+      @media (max-width: 349px) {
+        @content;
+      }
     }
-  }
 
-  @if ($breakpoint == tablet) {
-    @media (min-width: 500px) and (max-width: 767px) {
-      @content;
+    @if ($breakpoint == phone) {
+      @media (min-width: 350px) and (max-width: 499px) {
+        @content;
+      }
     }
-  }
 
-  @if ($breakpoint == large-tablet) {
-    @media (min-width: 768px) and (max-width: 991px) {
-      @content;
+    @if ($breakpoint == tablet) {
+      @media (min-width: 500px) and (max-width: 767px) {
+        @content;
+      }
     }
-  }
 
-  @if ($breakpoint == small-laptop) {
-    @media (min-width: 992px) and (max-width: 1200px) {
-      @content;
+    @if ($breakpoint == large-tablet) {
+      @media (min-width: 768px) and (max-width: 991px) {
+        @content;
+      }
     }
-  }
 
-  @if ($breakpoint == desktop) {
-    @media (min-width: 1200px) and (max-width: 1600px) {
-      @content;
+    @if ($breakpoint == small-laptop) {
+      @media (min-width: 992px) and (max-width: 1200px) {
+        @content;
+      }
     }
-  }
 
-  @if ($breakpoint == big-desktop) {
-    @media (min-width: 1601px) {
-      @content;
+    @if ($breakpoint == desktop) {
+      @media (min-width: 1200px) and (max-width: 1600px) {
+        @content;
+      }
+    }
+
+    @if ($breakpoint == big-desktop) {
+      @media (min-width: 1601px) {
+        @content;
+      }
     }
   }
 }
 
-/*
-Sample Usage:: 
-@use "~stylesheets/responsiveness"
-  @include responsiveness.screen(smallest) {
-
-  }
-  @include responsiveness.screen(phone) {
-
-  }
-  @include responsiveness.screen(tablet) {
-
-  }
-  @include responsiveness.screen(large-tablet) {
-
-  }
-  @include responsiveness.screen(small-laptop) {
-
-  }
-  @include responsiveness.screen(desktop) {
-
-  }
-  @include responsiveness.screen(big-desktop) {
-
-  }
-*/
 
 ///
 /// Viewport sized typography with minimum and maximum values


### PR DESCRIPTION
Problem
=======

I find myself having to copy code to apply styling for multiple breakpoints below a certain screen size.

Solution
========
What I/we did to solve this problem
* Update `responsiveness.screen()` mixin to take in one or more breakpoints.

This will copy the block of code for each breakpoint in the final CSS, so it won’t improve efficiency, but it should improve readability a bit.

Change Summary:
---------------


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  