### PR TITLE
changed App width from vw to percent

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -7,8 +7,8 @@ html,
 body,
 #root,
 #root > div {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  min-height: 100vh;
   margin: 0;
   padding: 0;
   overscroll-behavior: contain;

--- a/src/App.scss
+++ b/src/App.scss
@@ -8,7 +8,7 @@ body,
 #root,
 #root > div {
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   margin: 0;
   padding: 0;
   overscroll-behavior: contain;


### PR DESCRIPTION
Problem
=======
If the page overflowed vertically, it would overflow horizontally to because the scroll bar took up part of the viewport


Solution
========
Changed width units from vw to percent


Change Summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  