### PR TITLE
Having About page scale on larger screen sizes

### DIFF
--- a/src/views/Home/components/About/AboutBox/AboutBox.scss
+++ b/src/views/Home/components/About/AboutBox/AboutBox.scss
@@ -4,7 +4,8 @@
 .about-box {
     z-index: 1;
     border-radius: 33px;
-    width: 80%;
+    width: 70%;
+    max-width: 1500px;
     height: 100%;
     background-color: var(--color-dark-navy-blue);
     margin: 50px 0 50px 0;
@@ -17,10 +18,19 @@
         padding: 0 2% 0 2%;
         border-top-left-radius: 33px;
         border-top-right-radius: 33px;
-        @include responsiveness.font($responsive: 4.1vw, $min: 35px, $max: 80px);
+        @include responsiveness.font($responsive: 3.8vw, $min: 35px, $max: 80px);
         @include responsiveness.screen(smallest, phone) {
-            @include responsiveness.font($responsive: 7.1vw, $min: 22px, $max: 40px);
+            @include responsiveness.font($responsive: 7.1vw, $min: 20px, $max: 40px);
+            text-align: center;
             padding: 0 26px 0 30px;
+        }
+        @include responsiveness.screen(smallest) {
+            padding: 0 0 0 0px;
+            @include responsiveness.font($responsive: 7.1vw, $min: 20px, $max: 40px);
+            text-align: center;
+        }
+        @include responsiveness.screen(tablet) {
+            text-align: center;
         }
     }
     &__description {
@@ -30,7 +40,7 @@
         border-bottom-left-radius: 33px;
         border-bottom-right-radius: 33px;
         padding: 1% 4% 2% 4%;
-        @include responsiveness.font($responsive: 3.5vw, $min: 20px, $max: 35px);
+        @include responsiveness.font($responsive: 2.7vw, $min: 20px, $max: 32px);
 
         @include responsiveness.screen(smallest, phone, tablet) {
             padding: 10px 26px 20px 30px;

--- a/src/views/Home/components/About/AboutBox/AboutBox.scss
+++ b/src/views/Home/components/About/AboutBox/AboutBox.scss
@@ -10,6 +10,10 @@
     background-color: var(--color-dark-navy-blue);
     margin: 50px 0 50px 0;
     &__title {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        min-height: 50px;
         background-color: var(--color-text-primary);
         color: var(--color-dark-navy-blue);
         font-family: Source Sans Pro, "sans-serif";
@@ -25,7 +29,7 @@
             padding: 0 26px 0 30px;
         }
         @include responsiveness.screen(smallest) {
-            padding: 0 0 0 0px;
+            padding: 0;
             @include responsiveness.font($responsive: 7.1vw, $min: 20px, $max: 40px);
             text-align: center;
         }

--- a/src/views/Home/components/About/index.scss
+++ b/src/views/Home/components/About/index.scss
@@ -1,9 +1,10 @@
 @use "./stylesheets/responsiveness";
 
 .about-component {
-    background: linear-gradient(#8296D9,#BFACF0, #8F9ADD, #D99CE3);
+    background: linear-gradient(#8296D9, #8F9ADD,#BFACF0, #D99CE3);
     position: relative;
     z-index: 0;
+    margin-top: -1px;
     &__background {
         position: absolute;
         width: 100%;


### PR DESCRIPTION
Problem
=======
C2D-110 [Jira](https://cruzhacks-dev.atlassian.net/browse/C2D-110)



Solution
========
What I/we did to solve this problem
* Set a max-width to prevent stretching on widescreen
* Adjusted font-responsiveness to be smaller on desktop


Change Summary:
---------------
* Adjusted stylesheets AboutBox.scss and index.scss


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  