### PR TITLE
Fix hills graphics in the Footer component

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -40,7 +40,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    font-family: Source Sans Pro, sans-serif;
+    font-family: "Source Sans Pro", sans-serif;
     font-style: italic;
     @include responsiveness.font($responsive: 2.3vw, $min: 10px, $max: 28px);
   }

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -2,54 +2,73 @@
 @use "./stylesheets/typography";
 
 .footer-component {
-    &--icons {
-        display: flex;
-        justify-content: center;
-        gap: 2%;
-    }
-    &__link--wrapper {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        flex-shrink: 0;
-        padding: 1%;
-        height: 6vw;
-        width: 6vw;
-        max-height: 100px;
-        max-width: 100px;
-        min-height: 45px;
-        min-width: 45px;
-    }
-    &__link--icon {
-        transition: all 0.5s ease;
-        width: 80%;
-        height: 80%;
-        filter: drop-shadow(0px 1px 3px rgb(210, 213, 255));
-        
-    }
-    &__link--icon:hover {
-        filter: drop-shadow(-1px 1px 6px rgb(210, 213, 255));
-    }
+  margin-top: -1px;
 
-    &__text {
-        position: relative;
-        display: flex;
-        flex-direction: column;
-        font-family: Source Sans Pro, sans-serif;
-        font-style: italic;
-        @include responsiveness.font($responsive: 2.3vw, $min: 10px, $max: 28px);
-    }
-    &__text--copyright {
-        position: absolute;
-        right: 10%;
-        bottom: 10%;
-        @include responsiveness.screen(smallest) {
-            right: 0;
-        }
-    }
+  &--icons {
+    display: flex;
+    justify-content: center;
+    gap: 2%;
+  }
 
-}
-.hills {
+  &__link--wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 1%;
+    height: 6vw;
+    width: 6vw;
+    max-height: 100px;
+    max-width: 100px;
+    min-height: 45px;
+    min-width: 45px;
+  }
+
+  &__link--icon {
+    transition: all 0.5s ease;
+    width: 80%;
+    height: 80%;
+    filter: drop-shadow(0px 1px 3px rgb(210, 213, 255));
+
+  }
+
+  &__link--icon:hover {
+    filter: drop-shadow(-1px 1px 6px rgb(210, 213, 255));
+  }
+
+  &__text {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    font-family: Source Sans Pro, sans-serif;
+    font-style: italic;
+    @include responsiveness.font($responsive: 2.3vw, $min: 10px, $max: 28px);
+  }
+
+  &__text--copyright {
+    position: absolute;
+    right: 10%;
+    bottom: 10%;
+    @include responsiveness.screen(smallest) {
+      right: 0;
+    }
+  }
+
+  &__hills {
     width: 100%;
     height: 10%;
+
+    &--desktop {
+      @include responsiveness.screen(smallest, phone) {
+        display: none;
+      }
+    }
+
+    &--mobile {
+      display: none;
+      @include responsiveness.screen(smallest, phone) {
+        display: block;
+      }
+    }
+  }
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -2,7 +2,8 @@ import * as React from "react"
 import "./Footer.scss"
 import socials from "Props/footer/footer"
 import { FooterProps } from "Props/footer/props"
-import { ReactComponent as FooterHill } from "images/footer/footerhill.svg"
+import { ReactComponent as FooterHillDesktop } from "images/footer/footer-hills-desktop.svg"
+import { ReactComponent as FooterHillMobile } from "images/footer/footer-hills-mobile.svg"
 
 const Footer: React.FC<FooterProps> = ({ theme }: FooterProps) => (
   <div className='footer-component' style={{ background: theme.bgColor }}>
@@ -24,11 +25,19 @@ const Footer: React.FC<FooterProps> = ({ theme }: FooterProps) => (
       ))}
     </div>
     <div className='footer-component__text' style={{ color: theme.textColor }}>
-      <FooterHill className='hills' fill={theme.hillColor} />
+      <FooterHillDesktop
+        className='footer-component__hills footer-component__hills--desktop'
+        fill={theme.hillColor}
+      />
+      <FooterHillMobile
+        className='footer-component__hills footer-component__hills--mobile'
+        fill={theme.hillColor}
+      />
       <div className='footer-component__text--copyright'>
-        @ 2022 Cruzhacks. All rights reserved.
+        @ 2022 CruzHacks. All rights reserved.
       </div>
     </div>
   </div>
 )
+
 export default Footer

--- a/src/images/footer/footer-hills-desktop.svg
+++ b/src/images/footer/footer-hills-desktop.svg
@@ -1,3 +1,3 @@
-<svg width="1440" height="151" viewBox="0 0 1440 151" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg preserveAspectRatio="none" width="1440" height="151" viewBox="0 0 1440 151" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M0 151V21.906C1.55348e-06 13.6788 24.3559 -3.15478 156.283 1.40002C245.273 4.47257 451.407 107.781 556.393 92.8334C1005.23 28.9107 1356.36 -7.79166 1440 1.40004V151H15.4947H0Z" fill="current"/>
 </svg>

--- a/src/images/footer/footer-hills-mobile.svg
+++ b/src/images/footer/footer-hills-mobile.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" width="377" height="86" viewBox="0 0 377 86" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.36881 86L2.3688 37.5C2.3688 50.9666 -11.1152 19.3919 37 23C69.4556 25.434 122.71 50.8411 161 39C324.694 -11.6367 343 0 377 6.50003V85.2077L8.01989 86H2.36881Z" fill="current"/>
+</svg>


### PR DESCRIPTION
Problem
=======

The hills in Footer aren't tall enough on mobile [Jira](https://cruzhacks-dev.atlassian.net/browse/C2D-114)

<img width="200px" src="https://user-images.githubusercontent.com/20177171/136679514-0913a6bd-cc90-45bc-b4eb-7872e57abf44.png">
(Image from Alper)


Solution
========
What I/we did to solve this problem
* Exported another SVG with an aspect ratio more suitable for mobile
* Added `preserveAspectRatio="none"` to both SVGs so they will stretch when necessary


Change Summary:
---------------
* Fix footer hills on mobile
* Also remove the while line between Milestones and Footer
* Reindented the SCSS with 2 spaces


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  