### PR TITLE
Changing from 2000 minutes to 2 minutes

### DIFF
--- a/src/views/Dashboard/AnnouncementsListed/index.view.tsx
+++ b/src/views/Dashboard/AnnouncementsListed/index.view.tsx
@@ -16,11 +16,7 @@ const AnnouncementsListed: React.FC = () => {
           setError("Unable to Fetch Announcements")
         } else {
           setAnnouncements(JSON.parse(res.data.announcements))
-          store(
-            "announcements",
-            JSON.parse(res.data.announcements),
-            2 * 60 * 1000
-          )
+          store("announcements", JSON.parse(res.data.announcements), 2 * 60)
         }
       })
     } else {


### PR DESCRIPTION
Problem
=======
This is caching for 2000 minutes instead of 2 minutes [Jira](https://cruzhacks-dev.atlassian.net/jira/software/c/projects/C2D/issues/)



Solution
========
What I/we did to solve this problem
* Updated the caching timer


Change Summary:
---------------
* Fixing admin fetch to be more functional

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  