### PR TITLE
Removing Portal View Access for first launc

### DIFF
--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -3,7 +3,7 @@ import { Route, Switch } from "react-router-dom"
 import { useAuth0 } from "@auth0/auth0-react"
 import PrivateRoute from "../auth/PrivateRoute"
 import HomeView from "../views/Home/index.view"
-import PortalView from "../views/Portal/index.view"
+// import PortalView from "../views/Portal/index.view"
 import TeamView from "../views/Team/index.view"
 import ErrorView from "../views/Error/index.view"
 import DashboardView from "../views/Dashboard/index.view"
@@ -20,7 +20,7 @@ const Routes: React.FC = () => {
       <Switch>
         <Route exact path='/' component={HomeView} />
         <Route exact path='/team' component={TeamView} />
-        <PrivateRoute exact path='/portal' component={PortalView} />
+        {/* <PrivateRoute exact path='/portal' component={PortalView} /> */}
 
         <PrivateRoute
           exact


### PR DESCRIPTION
Problem
=======
C2D-118 [Jira](https://cruzhacks-dev.atlassian.net/browse/C2D-118)



Solution
========
What I/we did to solve this problem
* Removing Portal View for Release 1


Change Summary:
---------------
* Adjusting Routes.tsx


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* NOTE: This should be merged in only once the production configs have been tested