### PR TITLE
Fixing main page for safari users

### DIFF
--- a/src/components/EmailSubscription/index.scss
+++ b/src/components/EmailSubscription/index.scss
@@ -27,7 +27,7 @@
     width: 12%;
     min-width: 40px;
     padding: 8px;
-
+    display: flex;
     background: #FFFFFF;
     border: none;
     border-radius: 10px;

--- a/src/components/NavBar/NavBar.scss
+++ b/src/components/NavBar/NavBar.scss
@@ -6,10 +6,9 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: right;
+  justify-content: flex-end;
   padding: 12px 30px;
   &__links {
-    position: relative;
     &--link {
       margin: 5px 18px;
       color: var(--color-text-primary);


### PR DESCRIPTION
Problem: 
After Viewing Safari, I noticed some styles weren't be applied the same as they were on chrome. Navbar positioning is inaccurate and the arrow for mailing was getting sliced for safari (desktop).


Solution
========
What I/we did to solve this problem
* Modified styles with flex that were having issues


Change Summary:
---------------
* Updated navbar and emailing component to fix the position and sizing


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* This rehandled a previous bug and I would like to have this validated on multiple screens if possible

### Before on Safari
![Screen Shot 2021-10-12 at 10 45 24 PM](https://user-images.githubusercontent.com/38510322/137074954-08d799d0-1262-45c3-a98c-970c7777cbe0.png)
### After on Safari
![Screen Shot 2021-10-12 at 10 55 53 PM](https://user-images.githubusercontent.com/38510322/137075295-821b6891-da46-45d8-bc60-637380b350ad.png)