### PR TITLE
added redborders

### DIFF
--- a/src/stylesheets/_typography.scss
+++ b/src/stylesheets/_typography.scss
@@ -37,7 +37,6 @@
   font-style: italic;
   font-weight: 500;
   font-size: 36px;
-
 }
 
 @mixin card {
@@ -74,7 +73,6 @@
   margin-bottom: 30px;
 }
 
-
 @mixin form-prompts {
   color: var(--color-black);
   font-family: "Lato", sans-serif;
@@ -88,7 +86,6 @@
   width: 705px;
 }
 
-
 @mixin form-component-width {
   width: 585px;
   @include responsiveness.screen(tablet) {
@@ -101,7 +98,6 @@
     width: 208px;
   }
 }
-
 
 @mixin form-input-box {
   height: 40px;
@@ -141,9 +137,8 @@
   box-sizing: border-box;
 }
 
-
 @mixin form-error-message {
-  color: #FF0000;
+  color: #ff0000;
   font-family: "Lato", sans-serif;
   font-style: normal;
   font-weight: 400;
@@ -151,8 +146,8 @@
 }
 
 @mixin form-error-box {
+  border: 1px solid #ff0000;
 }
-
 
 @mixin form-page-container-styles {
   display: flex;

--- a/src/views/Portal/components/FormInputs/CheckBox/index.scss
+++ b/src/views/Portal/components/FormInputs/CheckBox/index.scss
@@ -13,6 +13,9 @@
   &__input {
     @include typography.form-input-box;
   }
+  &__error {
+    @include typography.form-error-box;
+  }
 
   &__selected-option {
     border: 1px solid #000000;
@@ -37,29 +40,39 @@
   &__option {
     appearance: none;
     width: 1.5em;
-    height: 1.5em; 
-    border: .12em solid black;
-    border-radius: .25em;
+    height: 1.5em;
+    border: 0.12em solid black;
+    border-radius: 0.25em;
     background-color: #fff;
     display: grid;
     place-content: center;
-    
+
     &::before {
       content: "";
       width: 1.05em;
       height: 1.05em;
       transform: scale(0);
-      background-color: #FE375B;
+      background-color: #fe375b;
       transform-origin: bottom left;
-      clip-path: polygon(50% 20%, 66% 5%, 88% 0, 100% 11%, 100% 40%, 50% 100%, 0 40%, 0 11%, 12% 0, 34% 5%);
+      clip-path: polygon(
+        50% 20%,
+        66% 5%,
+        88% 0,
+        100% 11%,
+        100% 40%,
+        50% 100%,
+        0 40%,
+        0 11%,
+        12% 0,
+        34% 5%
+      );
       transition: 120ms transform ease-in-out;
     }
     &:checked::before {
       transform: scale(1);
     }
-    &:hover{
-      border: .15em solid black;
+    &:hover {
+      border: 0.15em solid black;
     }
   }
-
 }

--- a/src/views/Portal/components/FormInputs/CheckBox/index.tsx
+++ b/src/views/Portal/components/FormInputs/CheckBox/index.tsx
@@ -35,7 +35,9 @@ const CheckBox: React.FC<CheckBoxProps> = ({
       <div className='checkbox-component__errorMessage'>{errorMessage}</div>
       <button
         type='button'
-        className='checkbox-component__input'
+        className={`checkbox-component__input ${
+          errorMessage ? "checkbox-component__error" : ""
+        }`}
         onClick={() => setViewSelected(!viewSelected)}
       >
         <div className='checkbox-component__selected-options'>

--- a/src/views/Portal/components/FormInputs/DropDown/index.scss
+++ b/src/views/Portal/components/FormInputs/DropDown/index.scss
@@ -21,8 +21,11 @@
     }
   }
 
+  &__error {
+    @include typography.form-error-box;
+  }
+
   &__option {
     @include typography.form-input-box;
   }
-
 }

--- a/src/views/Portal/components/FormInputs/DropDown/index.tsx
+++ b/src/views/Portal/components/FormInputs/DropDown/index.tsx
@@ -15,7 +15,9 @@ const DropDown: React.FC<DropDownProps> = ({
     <div className='dropdown-component__question'>{question}</div>
     <div className='dropdown-component__errorMessage'>{errorMessage}</div>
     <select
-      className='dropdown-component__selector'
+      className={`dropdown-component__selector ${
+        errorMessage ? "dropdown-component__error" : ""
+      }`}
       name={name}
       onChange={handleChange}
       value={value}

--- a/src/views/Portal/components/FormInputs/NumberBox/index.scss
+++ b/src/views/Portal/components/FormInputs/NumberBox/index.scss
@@ -14,4 +14,7 @@
   &__input {
     @include typography.form-input-box;
   }
+  &__error {
+    @include typography.form-error-box;
+  }
 }

--- a/src/views/Portal/components/FormInputs/NumberBox/index.tsx
+++ b/src/views/Portal/components/FormInputs/NumberBox/index.tsx
@@ -24,7 +24,9 @@ const NumberField: React.FC<NumberFieldProps> = ({
       max={max}
       maxLength={maxLength}
       onChange={handleChange}
-      className='number-field-component__input'
+      className={`number-field-component__input ${
+        errorMessage ? "number-field-component__error" : ""
+      }`}
     />
   </div>
 )

--- a/src/views/Portal/components/FormInputs/SearchBox/index.scss
+++ b/src/views/Portal/components/FormInputs/SearchBox/index.scss
@@ -14,6 +14,10 @@
     @include typography.form-input-box;
   }
 
+  &__error {
+    @include typography.form-error-box;
+  }
+
   // &__dropdown {
   //   @include typography.form-input-box;
   //   z-index: 2;
@@ -36,13 +40,13 @@
     width: 500px;
     height: 30px;
     @include typography.form-prompts;
-      @include responsiveness.screen(phone) {
-        width: 300px;
-        height: 25px;
-        }
-        @include responsiveness.screen(smallest) {
-        width: 200px;
-        height: 25px;
+    @include responsiveness.screen(phone) {
+      width: 300px;
+      height: 25px;
+    }
+    @include responsiveness.screen(smallest) {
+      width: 200px;
+      height: 25px;
     }
   }
   &--dropdown {
@@ -58,20 +62,23 @@
       @include responsiveness.screen(smallest) {
         width: 208px;
         height: 30px;
-        @include responsiveness.font($responsive: 2.3vw, $min: 12px, $max: 16px);
+        @include responsiveness.font(
+          $responsive: 2.3vw,
+          $min: 12px,
+          $max: 16px
+        );
       }
     }
-
   }
   &--checkbox {
     display: flex;
-    gap: .5em;
+    gap: 0.5em;
     &__box {
       appearance: none;
       width: 1.5em;
-      height: 1.5em; 
-      border: .12em solid black;
-      border-radius: .25em;
+      height: 1.5em;
+      border: 0.12em solid black;
+      border-radius: 0.25em;
       background-color: #fff;
       display: grid;
       place-content: center;
@@ -80,15 +87,15 @@
         width: 1.05em;
         height: 1.05em;
         transform: scale(0);
-        background-color: #FE375B;
+        background-color: #fe375b;
         transform-origin: center;
         transition: 120ms transform ease-in-out;
       }
       &:checked::before {
         transform: scale(1);
       }
-      &:hover{
-        border: .15em solid black;
+      &:hover {
+        border: 0.15em solid black;
       }
     }
   }

--- a/src/views/Portal/components/FormInputs/SearchBox/index.tsx
+++ b/src/views/Portal/components/FormInputs/SearchBox/index.tsx
@@ -70,7 +70,9 @@ const SearchBox: React.FC<SearchBoxProps> = ({
             name={label}
             value={fieldState}
             onChange={handleQueryChange}
-            className='search-box-component__input-box'
+            className={`search-box-component__input-box ${
+              errorMessage ? "search-box-component__error" : ""
+            }`}
           />
         </div>
         {dropdown()}

--- a/src/views/Portal/components/FormInputs/TextBox/index.scss
+++ b/src/views/Portal/components/FormInputs/TextBox/index.scss
@@ -10,9 +10,12 @@
     &__fieldName {
       @include typography.form-prompts;
     }
-  
+
     &__errorMessage {
       @include typography.form-error-message;
+    }
+    &__error {
+      @include typography.form-error-box;
     }
   }
 
@@ -25,9 +28,13 @@
     &__fieldName {
       @include typography.form-prompts;
     }
-  
+
     &__errorMessage {
       @include typography.form-error-message;
+    }
+
+    &__error {
+      @include typography.form-error-box;
     }
   }
 
@@ -40,13 +47,15 @@
     &__fieldName {
       @include typography.form-prompts;
     }
-  
+
     &__errorMessage {
       @include typography.form-error-message;
     }
+
+    &__error {
+      @include typography.form-error-box;
+    }
   }
-
-
 
   // &__input {
   //   &__large {

--- a/src/views/Portal/components/FormInputs/TextBox/index.tsx
+++ b/src/views/Portal/components/FormInputs/TextBox/index.tsx
@@ -22,7 +22,9 @@ const TextBox: React.FC<FieldProps> = ({
       value={fieldState}
       maxLength={maxLength}
       onChange={handleChange}
-      className={`text-box-component${className}__input`}
+      className={`text-box-component${className}__input ${
+        errorMessage ? `text-box-component${className}__error` : ""
+      }`}
     />
   </div>
 )

--- a/src/views/Portal/components/FormInputs/TextField/index.scss
+++ b/src/views/Portal/components/FormInputs/TextField/index.scss
@@ -14,8 +14,10 @@
   &__input {
     @include typography.form-input-box;
   }
+  &__error {
+    @include typography.form-error-box;
+  }
 }
-
 
 // .textField__component {
 //   @include typography.form-prompts;

--- a/src/views/Portal/components/FormInputs/TextField/index.tsx
+++ b/src/views/Portal/components/FormInputs/TextField/index.tsx
@@ -20,7 +20,9 @@ const TextField: React.FC<FieldProps> = ({
       value={fieldState}
       maxLength={maxLength}
       onChange={handleChange}
-      className='text-field-component__input'
+      className={`text-field-component__input ${
+        errorMessage ? "text-field-component__error" : ""
+      }`}
     />
   </div>
 )


### PR DESCRIPTION
Problem
=======
No red border around input fields when there is an errorMessage



Solution
========
What I/we did to solve this problem
* 


Change Summary:
---------------
* Added a new mixin for a red border around the inputs
* Included mixins in the form inputs that need it

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  