### PR TITLE
Prevent Footer from blocking click events

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -27,6 +27,7 @@
     .footer-component__graphics {
       position: absolute;
       bottom: 0;
+      pointer-events: none;
       z-index: 0;
     }
   }


### PR DESCRIPTION
Problem
=======
Footer padding is extending out of the container and causing it to block the click events of the FAQ component [Jira](https://cruzhacks-dev.atlassian.net/browse/C2D-149)

See: https://github.com/CruzHacks/cruzhacks-2022-website/pull/98#issuecomment-963385707.


Solution
========
What I/we did to solve this problem
* Prevent footer graphics from blocking click events
  * It'll still extend out of the container but hopefully it wouldn't block the click events anymore


Change Summary:
---------------


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* **Still need to test on mobile**