### PR TITLE
Helping Debugging for client and for us

### DIFF
--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -44,6 +44,7 @@ const ApplicationForm: React.FC = () => {
   } = useApplication()!
 
   const [successOnSubmit, setSubmitStatus] = useState("none")
+  const [serverErrors, setServerErrors] = useState<Array<string>>([])
   const viewNextPage = () => {
     if (page === ApplicationPages.Contact) {
       if (validateContactForm(contactFormData, setContactFormData, true)) {
@@ -124,7 +125,7 @@ const ApplicationForm: React.FC = () => {
       bodyData.append("currentStanding", demographicFormData.currentStanding)
       bodyData.append("country", demographicFormData.country)
       bodyData.append("whyCruzHacks", shortAnswerFormData.whyCruzHacks)
-      bodyData.append("newThisYear", priorExperienceFormData.firstCruzHacks)
+      bodyData.append("newThisYear", shortAnswerFormData.newThisYear)
       bodyData.append(
         "grandestInvention",
         shortAnswerFormData.grandestInvention
@@ -155,7 +156,17 @@ const ApplicationForm: React.FC = () => {
         setAppStatus(AppStatus.Pending)
         setSubmitting(false)
       }
-    } catch (err) {
+    } catch (err: any) {
+      if (
+        err &&
+        err.response &&
+        err.response.data &&
+        err.response.data.errors
+      ) {
+        setServerErrors(err.response.data.errors)
+      } else {
+        setServerErrors([])
+      }
       setSubmitStatus("error submitting")
       setSubmitting(false)
     }
@@ -198,10 +209,28 @@ const ApplicationForm: React.FC = () => {
           {successOnSubmit === "submitted" ? "submitted" : ""}
         </div>
         <div className='application-form-component__response-err'>
-          {successOnSubmit === "error submitting"
+          {successOnSubmit === "error submitting" && serverErrors.length === 0
             ? "CruzHacks Cloud had an error processing your application. There may be a high bandwidth of users at this moment. Our engineers have been alerted! Try again soon!"
             : ""}
         </div>
+
+        {successOnSubmit === "error submitting" && serverErrors.length > 0 && (
+          <div className='application-form-component__response-err'>
+            Server Errors:
+          </div>
+        )}
+
+        {successOnSubmit === "error submitting" &&
+          serverErrors.length > 0 &&
+          serverErrors.map((error: string) => (
+            <div
+              className='application-form-component__response-err'
+              key={error}
+            >
+              {error}
+            </div>
+          ))}
+
         <div className='application-form-component__buttons'>
           <button
             className='application-form-component__button'


### PR DESCRIPTION
Problem
=======
If we run into issues from our phone, being able to view the server errors will be significantly more helpful for debugging + if a user runs into it (we can debug their problem quicker).



Solution
========
What I/we did to solve this problem
* Stored server errors from our app inside a variable to be mapped in the situation this occurs
* The goal is stress test enough to have this never appear 
* If it does appear a client can potentially resolve the issue themselves or let us know.


Change Summary:
---------------
* Updated ApplicationForm.tsx
* Fixed newThisYear formData sent instead of firstCruzHacks 

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  