### PR TITLE
Adding scaling for large tablet

### DIFF
--- a/src/stylesheets/_typography.scss
+++ b/src/stylesheets/_typography.scss
@@ -84,6 +84,9 @@
 
 @mixin form-component-width-large {
   width: 705px;
+  @include responsiveness.screen(large-tablet) {
+    width: 505px;
+  }
   @include responsiveness.screen(tablet) {
     width: 400px;
   }


### PR DESCRIPTION
Problem
=======
Scaling on Larger Tablet has been Improved for TextBoxes



Solution
========
What I/we did to solve this problem
* Changed the mixin to reduce screen container size on larger-tablets


Change Summary:
---------------
* Updated typography.scss

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Updated Change 811x1117:
<img width="394" alt="page3-tablet" src="https://user-images.githubusercontent.com/38510322/141600689-fb690250-b407-4df7-8d86-5b79390d1579.PNG">