### PR TITLE
fixed math div depreactation notice and Typescript error for API keys

### DIFF
--- a/src/stylesheets/_responsiveness.scss
+++ b/src/stylesheets/_responsiveness.scss
@@ -7,6 +7,8 @@ Sample usage::
    @include responsiveness.screen(phone, tablet, large-tablet) {
    }
  */
+@use 'sass:math';
+
 @mixin screen($breakpoints...) {
   @each $breakpoint in $breakpoints {
     @if ($breakpoint == smallest) {
@@ -71,16 +73,16 @@ Sample usage::
 ///  @include font(5vw, 35px, 150px, 50px);
 ///
 @mixin font($responsive, $min, $max: false, $fallback: false) {
-  $responsive-unitless: $responsive / ($responsive - $responsive + 1);
+  $responsive-unitless: math.div($responsive, ($responsive - $responsive + 1));
   $dimension: if(unit($responsive) == "vh", "height", "width");
-  $min-breakpoint: $min / $responsive-unitless * 100;
+  $min-breakpoint: math.div($min, $responsive-unitless * 100);
 
   @media (max-#{$dimension}: #{$min-breakpoint}) {
     font-size: $min;
   }
 
   @if $max {
-    $max-breakpoint: $max / $responsive-unitless * 100;
+    $max-breakpoint: math.div($max, $responsive-unitless * 100);
 
     @media (min-#{$dimension}: #{$max-breakpoint}) {
       font-size: $max;

--- a/src/stylesheets/_responsiveness.scss
+++ b/src/stylesheets/_responsiveness.scss
@@ -75,14 +75,14 @@ Sample usage::
 @mixin font($responsive, $min, $max: false, $fallback: false) {
   $responsive-unitless: math.div($responsive, ($responsive - $responsive + 1));
   $dimension: if(unit($responsive) == "vh", "height", "width");
-  $min-breakpoint: math.div($min, $responsive-unitless * 100);
+  $min-breakpoint: math.div($min * 100, $responsive-unitless );
 
   @media (max-#{$dimension}: #{$min-breakpoint}) {
     font-size: $min;
   }
 
   @if $max {
-    $max-breakpoint: math.div($max, $responsive-unitless * 100);
+    $max-breakpoint: math.div($max * 100, $responsive-unitless);
 
     @media (min-#{$dimension}: #{$max-breakpoint}) {
       font-size: $max;

--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -72,8 +72,8 @@ export function subscribeMailchimp(userEmail: string) {
 export function verifyRecaptchaToken(res: string | null, callback: any) {
   const axiosConfig: AxiosRequestConfig = {
     headers: {
-      Authentication: API_KEY,
-      token: res,
+      Authentication: API_KEY || "",
+      token: res || "",
     },
   }
   axios
@@ -90,7 +90,7 @@ export function verifyRecaptchaToken(res: string | null, callback: any) {
 export function getAllAnnouncements() {
   const axiosConfig: AxiosRequestConfig = {
     headers: {
-      Authentication: API_KEY,
+      Authentication: API_KEY || "",
     },
   }
   return axios.get(ANNOUNCEMENT_ENDPOINT, axiosConfig)


### PR DESCRIPTION
Problem
=======
[C2D-155](https://cruzhacks-dev.atlassian.net/browse/C2D-155?atlOrigin=eyJpIjoiM2E1N2VlYjQyMGVmNDRiZDg5NzYxMjU1MzQwOWE0N2MiLCJwIjoiaiJ9)


Solution
========
What I/we did to solve this problem
* Fixed API deprecation notice


Change Summary:
---------------
* Updated Responsiveness Font function to use math.div() instead of /
* Updated API functions that use API key to set to empty string if env is NULL

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  