### PR TITLE
Updating Verify Text + Adding Success/Fail Message

### DIFF
--- a/src/components/ResendVerification/index.scss
+++ b/src/components/ResendVerification/index.scss
@@ -1,3 +1,6 @@
+@use "./stylesheets/responsiveness";
+@use "./stylesheets/typography";
+
 .resendVerification-component {
     display:flex;
     flex-direction: column;
@@ -6,6 +9,23 @@
     padding-bottom: 8%;
     &__recaptcha {
         margin-bottom: 5%;
+    }
+    &__response {
+        text-align: center;
+        margin-top: 2%;
+        font-family: "Source Sans Pro", sans-serif;
+        font-style: normal;
+        font-weight: normal;
+        @include responsiveness.font(3.1vw, 14px, 32px);
+
+        @include responsiveness.screen(smallest, mobile) {
+            @include responsiveness.font(3.5vw, 12px, 20px);
+        }
+
+        @include responsiveness.screen(desktop, big-desktop) {
+            margin-bottom: 4%;
+            font-size: 32px;
+        }
     }
     
 }

--- a/src/components/ResendVerification/index.tsx
+++ b/src/components/ResendVerification/index.tsx
@@ -12,6 +12,18 @@ const ResendVerification: React.FC<VerificationEmailProps> = ({
   token,
 }: VerificationEmailProps) => {
   const [verified, setVerified] = useState<boolean>(false)
+  const [response, setResponse] = useState<string>("")
+  const onClick = () => {
+    resendVerificationEmail(user, token)
+      .then(res => {
+        if (res.status === 201) {
+          setResponse("Successfully Resent Verify Email")
+        } else {
+          setResponse("Failed to Resend")
+        }
+      })
+      .catch(() => setResponse("Failed to Resend"))
+  }
   return (
     <div className='resendVerification-component'>
       <div className='resendVerification-component__recaptcha'>
@@ -26,12 +38,13 @@ const ResendVerification: React.FC<VerificationEmailProps> = ({
         label='resend'
         disabled={!verified}
         duration={1000 * 30}
-        onClick={() => {
-          resendVerificationEmail(user, token)
-        }}
+        onClick={onClick}
       >
         Resend Verification Email
       </CoolDownButton>
+      {response && (
+        <div className='resendVerification-component__response'>{response}</div>
+      )}
     </div>
   )
 }

--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -37,7 +37,7 @@ export function resendVerificationEmail(
   const body = {
     userId,
   }
-  axios
+  return axios
     .post(RESEND_VERIFICATION_EMAIL_ENDPOINT, body, axiosConfig)
     .then((res: AxiosResponse) => res)
     .catch(err => err)

--- a/src/views/Verify/VerifyMessages/VerifyMessage.tsx
+++ b/src/views/Verify/VerifyMessages/VerifyMessage.tsx
@@ -10,17 +10,22 @@ const VerifyMessages: React.FC = () => {
       key: "Line 1",
     },
     {
-      message: `Please check your email for a verification from dev@cruzhacks.com. If you do not see a verification email, please check your spam or you can request another verification email below.`,
+      message: `Please check your email for a verification from dev@cruzhacks.com. If you do not see a verification email, please check your spam.`,
       key: "Line 2",
     },
     {
       message:
-        "Once you have verified your email, please sign out and sign in again to have full access. If you are experiencing any issues send a message to dev@cruzhacks.com.",
+        "If you still cannot find it, you can resend a verification email below once every 30 seconds.",
       key: "Line 3",
     },
     {
-      message: "We are excited to see you at CruzHacks 2022!",
+      message:
+        "Once you have verified your email, please refresh your browser to have full access. If you are experiencing any issues send a message to dev@cruzhacks.com.",
       key: "Line 4",
+    },
+    {
+      message: "We are excited to see you at CruzHacks 2022!",
+      key: "Line 5",
     },
   ]
   return (


### PR DESCRIPTION
Problem
=======
Verification Text no longer needs to say logout and sign in again. Need Some response to indicate success or failure of verification function.



Solution
========
What I/we did to solve this problem
* Updated Resend Verification to include to store Response
* Updated Endpoint Function for sending request to return the promise
* Updated Text for lines displayed


Change Summary:
---------------
* Updated Verification.tsx with error/success message
* Rewrote the the text in Verification Messages
* resendVerification function in Api.ts now returns a promise
* Added styles for new success/error message

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  