### PR TITLE
Portal: Add loading indicator

### DIFF
--- a/src/views/Portal/components/ApplicationForm/index.scss
+++ b/src/views/Portal/components/ApplicationForm/index.scss
@@ -56,6 +56,7 @@
     display: flex;
     justify-content: center;
     @include typography.form-prompts;
+    color: #00b300;
   }
   &__response-err {
     display: flex;

--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -214,6 +214,11 @@ const ApplicationForm: React.FC = () => {
             : ""}
         </div>
 
+        {submitting && (
+          <div className='application-form-component__response'>
+            Submitting...
+          </div>
+        )}
         {successOnSubmit === "error submitting" && serverErrors.length > 0 && (
           <div className='application-form-component__response-err'>
             Server Errors:
@@ -265,7 +270,7 @@ const ApplicationForm: React.FC = () => {
                 )
               }
             >
-              Submit
+              {submitting ? "Loading..." : "Submit"}
             </button>
           )}
         </div>


### PR DESCRIPTION
Problem
=======
When submitting, we need some indication that the request is taking place [Jira](https://cruzhacks-dev.atlassian.net/browse/C2D-169/)


Solution
========
What I/we did to solve this problem
* Add a "Submitting..." message and change button text to loading


Change Summary:
---------------
* Add some feedback when submitting [f088164]
* 
Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
