### PR TITLE
Updating MLH page, adding graduation component

### DIFF
--- a/src/Props/application/props.ts
+++ b/src/Props/application/props.ts
@@ -22,6 +22,7 @@ export interface SerializableDemographicProps {
   eventLocation: string
   major: string
   currentStanding: string
+  graduation: string
   country: string
 }
 
@@ -35,6 +36,7 @@ export interface DemographicProps extends SerializableDemographicProps {
   eventLocationErr: string
   majorErr: string
   currentStandingErr: string
+  graduationErr: string
   countryErr: string
 }
 
@@ -82,6 +84,7 @@ export interface ConnectedProps extends SerializableConnectedProps {
 export interface SerializableMLHProps {
   conductAgree: string
   tosAgree: string
+  communicationAgree: string
 }
 
 export interface MLHProps extends SerializableMLHProps {

--- a/src/components/ApplicationContext/ApplicationContext.tsx
+++ b/src/components/ApplicationContext/ApplicationContext.tsx
@@ -191,6 +191,7 @@ export const ApplicationProvider: React.FC = () => {
         eventLocation,
         major,
         currentStanding,
+        graduation,
         country,
       } = demographicFormData
       formData.demographic = {
@@ -203,6 +204,7 @@ export const ApplicationProvider: React.FC = () => {
         eventLocation,
         major,
         currentStanding,
+        graduation,
         country,
       }
     } else if (page === ApplicationPages.ShortAnswer) {

--- a/src/views/Portal/components/ApplicationForm/Demographic/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/Demographic/index.view.tsx
@@ -187,7 +187,7 @@ const DemographicPage: React.FC = () => {
           </div>
           <div className='demographic-page-container__field'>
             <NumberField
-              name='Graduation Year'
+              name='Graduation Year *'
               handleChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setDemographicFormData(prev => ({
                   ...prev,

--- a/src/views/Portal/components/ApplicationForm/Demographic/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/Demographic/index.view.tsx
@@ -175,16 +175,30 @@ const DemographicPage: React.FC = () => {
               value={demographicFormData.currentStanding}
               errorMessage={demographicFormData.currentStandingErr}
               inputs={[
-                { label: "N/A" },
-                { label: "Freshman" },
-                { label: "Sophomore" },
-                { label: "Junior" },
-                { label: "Senior" },
-                { label: "Super-Senior" },
-                { label: "Post-Graduate" },
+                { label: "High School" },
+                { label: "Bachelors" },
+                { label: "Masters" },
+                { label: "PhD" },
+                { label: "Other" },
               ]}
               name='currentStanding'
               handleChange={handleChange}
+            />
+          </div>
+          <div className='demographic-page-container__field'>
+            <NumberField
+              name='Graduation Year'
+              handleChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setDemographicFormData(prev => ({
+                  ...prev,
+                  graduation: e.target.value,
+                }))
+              }}
+              fieldState={demographicFormData.graduation}
+              errorMessage={demographicFormData.graduationErr}
+              label='graduationYear'
+              min={1950}
+              max={2050}
             />
           </div>
           <div className='demographic-page-container__field'>

--- a/src/views/Portal/components/ApplicationForm/MLH/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/MLH/index.view.tsx
@@ -73,6 +73,30 @@ const MLHPage: React.FC = () => {
           errorMessage=''
           value={mlhFormData.tosAgree}
         />
+        <div className='mlh-page-container__TAC'>
+          I authorize MLH to send me pre- and post-event informational emails
+          which contain free credit and opportunities from their partners.
+        </div>
+        <RadioForm
+          question='Communication from MLH'
+          inputs={[
+            {
+              label: "I have read and agree to the terms outlined above.",
+            },
+            {
+              label: "I do not agree to the terms above.",
+            },
+          ]}
+          name='communicationAgree'
+          handleChange={(e: any) =>
+            setmlhFormData(prev => ({
+              ...prev,
+              communicationAgree: e.target.value,
+            }))
+          }
+          errorMessage=''
+          value={mlhFormData.communicationAgree}
+        />
       </div>
     </div>
   )

--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -133,6 +133,7 @@ const ApplicationForm: React.FC = () => {
       bodyData.append("eventLocation", demographicFormData.eventLocation)
       bodyData.append("major", demographicFormData.major)
       bodyData.append("currentStanding", demographicFormData.currentStanding)
+      bodyData.append("graduation", demographicFormData.graduation)
       bodyData.append("country", demographicFormData.country)
       bodyData.append("whyCruzHacks", shortAnswerFormData.whyCruzHacks)
       bodyData.append("newThisYear", shortAnswerFormData.newThisYear)
@@ -274,6 +275,8 @@ const ApplicationForm: React.FC = () => {
                   mlhFormData.conductAgree ===
                     "I have read and agree to abide by the MLH Code of Conduct at CruzHacks." &&
                   mlhFormData.tosAgree ===
+                    "I have read and agree to the terms outlined above." &&
+                  mlhFormData.communicationAgree ===
                     "I have read and agree to the terms outlined above."
                 )
               }

--- a/src/views/Portal/utils/PropBuilder.ts
+++ b/src/views/Portal/utils/PropBuilder.ts
@@ -71,6 +71,7 @@ export const generateDemographicProps = (
     eventLocation: props?.eventLocation || "",
     major: props?.major || "",
     currentStanding: props?.currentStanding || "",
+    graduation: props?.graduation || "0",
     country: props?.country || "",
     ageErr: "",
     pronounsErr: "",
@@ -81,6 +82,7 @@ export const generateDemographicProps = (
     eventLocationErr: "",
     majorErr: "",
     currentStandingErr: "",
+    graduationErr: "",
     countryErr: "",
   }
   return newObj
@@ -106,6 +108,7 @@ export const generateMLHProps = (props?: SerializableMLHProps) => {
   const newObj: MLHProps = {
     conductAgree: props?.conductAgree || "No",
     tosAgree: props?.tosAgree || "No",
+    communicationAgree: props?.tosAgree || "No",
     agreementErr: "",
   }
   return newObj

--- a/src/views/Portal/utils/validation.ts
+++ b/src/views/Portal/utils/validation.ts
@@ -134,6 +134,7 @@ export const validatedemographicForm = (
     "eventLocation",
     "major",
     "currentStanding",
+    "graduation",
     "country",
   ]
   let isValid = true
@@ -147,12 +148,13 @@ export const validatedemographicForm = (
     eventLocation,
     major,
     currentStanding,
+    graduation,
     country,
   } = pageData
   const pronounCount = pronouns.length
   const sexaulityCount = sexuality.length
   const ageInt = parseInt(age, 10)
-
+  const gradInt = parseInt(graduation, 10)
   const validAffiliation = [
     "i am not a ucsc student",
     "i am a ucsc grad student with no college affiliation",
@@ -192,6 +194,9 @@ export const validatedemographicForm = (
             "ageErr",
             dispatchError
           )
+        } else if (Number.isNaN(ageInt)) {
+          isValid = false
+          updateErrorMessage("Please Input a Response", "ageErr", dispatchError)
         } else {
           updateErrorMessage("", "ageErr", dispatchError)
         }
@@ -440,6 +445,25 @@ export const validatedemographicForm = (
           updateErrorMessage("", "currentStandingErr", dispatchError)
         }
         break
+      case "graduation":
+        if (gradInt < 1950 || gradInt > 2050) {
+          isValid = false
+          updateErrorMessage(
+            "Inputted Year must be between 1950 - 2050",
+            "graduationErr",
+            dispatchError
+          )
+        } else if (Number.isNaN(gradInt)) {
+          isValid = false
+          updateErrorMessage(
+            "Please Input a Response",
+            "graduationErr",
+            dispatchError
+          )
+        } else {
+          updateErrorMessage("", "graduationErr", dispatchError)
+        }
+        break
       case "country":
         if (onSubmit && country.length === 0) {
           isValid = false
@@ -601,6 +625,13 @@ export const validatepriorExperienceForm = (
         } else if (hackathonsCountInt > 100) {
           isValid = false
           updateErrorMessage("Limit is 100", "hackathonCountErr", dispatchError)
+        } else if (Number.isNaN(hackathonsCountInt)) {
+          isValid = false
+          updateErrorMessage(
+            "Please Input a Response",
+            "hackathonCountErr",
+            dispatchError
+          )
         } else {
           updateErrorMessage("", "hackathonCountErr", dispatchError)
         }


### PR DESCRIPTION
Problem
=======
MLH has requested that we store graduation year, current study as current program, and additional MLH services.



Solution
========
What I/we did to solve this problem
* Updated current level of study choices
* Created Additional Field for graduation Year
* Added additional MLH constraint


Change Summary:
---------------
* Updated MLH Page
* Updated Validation and Props
* Updated Demographics Page

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* This is Intended to be run with https://github.com/CruzHacks/cruzhacks-2022-backend/pull/61 