### PR TITLE
Only show unsaved changes prompt if app is in progress

### DIFF
--- a/src/components/ApplicationContext/ApplicationContext.tsx
+++ b/src/components/ApplicationContext/ApplicationContext.tsx
@@ -42,6 +42,7 @@ interface ApplicationContextProps {
   savePage: any
 
   // track if user has inputted data
+  newChangesRef: any
   setNewChanges: any
 
   submitting: boolean
@@ -174,26 +175,6 @@ export const ApplicationProvider: React.FC = () => {
       .catch(() => setStatus(AppStatus.Errored))
   }, [])
 
-  useEffect(() => {
-    // notify user if they are trying to leave the page after working on the app
-    const confirmLeave = (ev: BeforeUnloadEvent) => {
-      if (
-        (status === AppStatus.NotFound || status === AppStatus.InProgress) &&
-        newChanges.current
-      ) {
-        ev.preventDefault()
-
-        // eslint-disable-next-line no-param-reassign
-        ev.returnValue = "Are you sure?"
-      }
-    }
-
-    window.addEventListener("beforeunload", confirmLeave)
-    return () => {
-      window.removeEventListener("beforeunload", confirmLeave)
-    }
-  }, [status])
-
   const savePage = () => {
     const formData: SavedApplication = retrieve("application", {}, user?.email)
 
@@ -275,6 +256,7 @@ export const ApplicationProvider: React.FC = () => {
         accessToken: token,
         nextPage,
         prevPage,
+        newChangesRef: newChanges,
         setNewChanges: () => {
           newChanges.current = true
         },

--- a/src/components/ApplicationContext/ApplicationContext.tsx
+++ b/src/components/ApplicationContext/ApplicationContext.tsx
@@ -177,7 +177,10 @@ export const ApplicationProvider: React.FC = () => {
   useEffect(() => {
     // notify user if they are trying to leave the page after working on the app
     const confirmLeave = (ev: BeforeUnloadEvent) => {
-      if (newChanges.current) {
+      if (
+        (status === AppStatus.NotFound || status === AppStatus.InProgress) &&
+        newChanges.current
+      ) {
         ev.preventDefault()
 
         // eslint-disable-next-line no-param-reassign
@@ -189,7 +192,7 @@ export const ApplicationProvider: React.FC = () => {
     return () => {
       window.removeEventListener("beforeunload", confirmLeave)
     }
-  }, [])
+  }, [status])
 
   const savePage = () => {
     const formData: SavedApplication = retrieve("application", {}, user?.email)

--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import "./index.scss"
 import axios from "axios"
 import { useAuth0 } from "@auth0/auth0-react"
@@ -28,6 +28,7 @@ const ApplicationForm: React.FC = () => {
     prevPage,
     nextPage,
     savePage,
+    newChangesRef,
     submitting,
     setSubmitting,
     setAppStatus,
@@ -92,6 +93,23 @@ const ApplicationForm: React.FC = () => {
   const viewPrevPage = () => {
     prevPage()
   }
+
+  useEffect(() => {
+    // notify user if they are trying to leave the form after working on the app
+    const confirmLeave = (ev: BeforeUnloadEvent) => {
+      if (newChangesRef.current) {
+        ev.preventDefault()
+
+        // eslint-disable-next-line no-param-reassign
+        ev.returnValue = "Are you sure?"
+      }
+    }
+
+    window.addEventListener("beforeunload", confirmLeave)
+    return () => {
+      window.removeEventListener("beforeunload", confirmLeave)
+    }
+  })
 
   const { user } = useAuth0()
   const submitData = async () => {


### PR DESCRIPTION
Problem
=======

After Submitting, when closing the tab the unsaved changes prompt still runs [Jira](https://cruzhacks-dev.atlassian.net/browse/C2D-178)



Solution
========
What I/we did to solve this problem
* ~~Add status dependency to the useEffect hook for the unsaved changes prompt~~
* Move unsaved changes check to `ApplicationForm`



Change Summary:
---------------


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  