### PR TITLE
Changing Application Endpoint Routing

### DIFF
--- a/src/utils/Api.ts
+++ b/src/utils/Api.ts
@@ -15,7 +15,8 @@ const ANNOUNCEMENT_ENDPOINT =
 const APPLICATION_ENDPOINT =
   `${process.env.REACT_APP_ENDPOINT_URL}/application` || ""
 
-const ANALYTICS_ENDPOINT = `${APPLICATION_ENDPOINT}/analytics` || ""
+const ANALYTICS_ENDPOINT =
+  `${process.env.REACT_APP_ENDPOINT_URL}/analytics/` || ""
 const CHECK_APPLICATION_ENDPOINT = `${APPLICATION_ENDPOINT}/checkApp` || ""
 
 const API_KEY = process.env.REACT_APP_API_KEY


### PR DESCRIPTION
Problem
=======
The analytics Endpoint will be splitting from application endpoint to reduce cold start on backend.



Solution
========
What I/we did to solve this problem
* Renamed the route to call analytics


Change Summary:
---------------
* Updated Api.ts

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  