### PR TITLE
Adding additional information to team page requested by Execs

### DIFF
--- a/src/views/Team/index.scss
+++ b/src/views/Team/index.scss
@@ -28,7 +28,7 @@
     display: flex;
     justify-content: center;
     width: 100%;
-    margin-bottom: 50px;
+    margin-bottom: 40px;
     &--msg {
       text-align:center;
       @include typography.our-team-message;

--- a/src/views/Team/index.view.tsx
+++ b/src/views/Team/index.view.tsx
@@ -21,6 +21,12 @@ const TeamView: React.FC = () => (
     </div>
     <div className='team-view__special-thanks-container'>
       <div className='team-view__special-thanks-container--msg'>
+        CruzHacks was founded as Hack UCSC by Mark Adams, Brent Haddad, and Doug
+        Erickson
+      </div>
+    </div>
+    <div className='team-view__special-thanks-container'>
+      <div className='team-view__special-thanks-container--msg'>
         Special thanks to our Board of Directors: Doug Erickson, Nathan Westrup,
         Amanda Rotella, Nada Miljkovic, and Drew Meyer.
       </div>


### PR DESCRIPTION
Problem
=======
The Execs want to append a little more information about the founders of CruzHacks for the 10th Anniversary.



Solution
========
What I/we did to solve this problem
* Updated Team Page with sentence from Execs.


Change Summary:
---------------
* Updated Team Page .tsx/.scss

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  