### PR TITLE
Updating Error Message to Tell user to Refresh Browser

### DIFF
--- a/src/components/ApplicationContext/ApplicationContext.tsx
+++ b/src/components/ApplicationContext/ApplicationContext.tsx
@@ -37,6 +37,7 @@ interface ApplicationContextProps {
   appStatus: number
   setAppStatus: Dispatch<SetStateAction<number>>
   accessToken: string
+  setToken: Dispatch<SetStateAction<string>>
   nextPage: any
   prevPage: any
   savePage: any
@@ -254,6 +255,7 @@ export const ApplicationProvider: React.FC = () => {
         appStatus: status,
         setAppStatus: setStatus,
         accessToken: token,
+        setToken,
         nextPage,
         prevPage,
         newChangesRef: newChanges,

--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -33,6 +33,7 @@ const ApplicationForm: React.FC = () => {
     setSubmitting,
     setAppStatus,
     accessToken,
+    setToken,
     progress,
     contactFormData,
     setContactFormData,
@@ -111,7 +112,7 @@ const ApplicationForm: React.FC = () => {
     }
   })
 
-  const { user } = useAuth0()
+  const { user, getAccessTokenSilently } = useAuth0()
   const submitData = async () => {
     try {
       // save the progress first
@@ -198,6 +199,11 @@ const ApplicationForm: React.FC = () => {
         setServerErrors(err.response.data.errors)
       } else {
         setServerErrors([])
+      }
+      if (err && err.response === 401) {
+        getAccessTokenSilently()
+          .then(data => setToken(data))
+          .catch(() => setToken(""))
       }
       setSubmitStatus("error submitting")
       setSubmitting(false)

--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -242,7 +242,7 @@ const ApplicationForm: React.FC = () => {
         </div>
         <div className='application-form-component__response-err'>
           {successOnSubmit === "error submitting" && serverErrors.length === 0
-            ? "CruzHacks Cloud had an error processing your application. There may be a high bandwidth of users at this moment. Our engineers have been alerted! Try again soon!"
+            ? "CruzHacks Cloud had an error processing your application. There may be a high bandwidth of users at this moment or your session has expired. Please try to refresh your browser. Our engineers have been alerted! Try again soon!"
             : ""}
         </div>
 

--- a/src/views/Portal/components/ApplicationForm/index.view.tsx
+++ b/src/views/Portal/components/ApplicationForm/index.view.tsx
@@ -200,7 +200,7 @@ const ApplicationForm: React.FC = () => {
       } else {
         setServerErrors([])
       }
-      if (err && err.response === 401) {
+      if (err && err.response && err.response.status === 401) {
         getAccessTokenSilently()
           .then(data => setToken(data))
           .catch(() => setToken(""))


### PR DESCRIPTION
Problem
=======
Some users are unable to submit because auth tokens are expiring due to their session timing out and may not know to refresh their browser.



Solution
========
What I/we did to solve this problem
* Updated the error message Text to tell user to refresh browser
* Rerequesting token if session is still available


Change Summary:
---------------
* Updated ApplicationForm

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  