### PR TITLE
Closing Application Portal

### DIFF
--- a/src/views/Portal/components/ApplicationStatus/index.view.tsx
+++ b/src/views/Portal/components/ApplicationStatus/index.view.tsx
@@ -25,8 +25,8 @@ const ApplicationStatus: React.FC = () => {
         setStatusMessage("REJECTED")
         break
       case AppStatus.NotFound:
-        setStatusMessage("NOT STARTED")
-        // setStatusMessage("CLOSED") Uncomment to Close Applications
+        // setStatusMessage("NOT STARTED")
+        setStatusMessage("CLOSED")
         break
       case AppStatus.InProgress:
         setStatusMessage("IN PROGRESS")


### PR DESCRIPTION
Problem
=======
The application Portal should no longer be accessible after December 15th.



Solution
========
What I/we did to solve this problem
* Updated the State to show that the portal is closed


Change Summary:
---------------
* Updated Application Status View

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  