### PR TITLE
Removing Application From Navbar, Indicating Status as Closed

### DIFF
--- a/src/Props/navbar/navbar.ts
+++ b/src/Props/navbar/navbar.ts
@@ -9,10 +9,10 @@ const NavbarRoutes: NavbarRouteProps[] = [
     route: "/team",
     name: "TEAM",
   },
-  {
-    route: "/portal",
-    name: "APPLY",
-  },
+  // {
+  //   route: "/portal",
+  //   name: "APPLY",
+  // },
 ]
 
 export default NavbarRoutes

--- a/src/views/Home/components/Landing/index.tsx
+++ b/src/views/Home/components/Landing/index.tsx
@@ -48,9 +48,9 @@ const Landing: React.FC = () => {
                   className='landing-component__button'
                   modifier='primary'
                   label='sponsor button'
-                  href='mailto:sponsor@cruzhacks.com'
+                  href='https://docs.google.com/forms/d/e/1FAIpQLSfXrKQS69kBkP6J5yfJRKP9XqDOqk_AW3Cq-Ya-kEXTfQOHUg/viewform'
                 >
-                  become a sponsor
+                  mentor/judge application
                 </Button>
                 <Button
                   className='landing-component__button'
@@ -59,7 +59,7 @@ const Landing: React.FC = () => {
                   href='/portal'
                   redirect
                 >
-                  apply now
+                  hacker apps closed
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
Problem
=======
Users need to know that the Application Portal is closed and that judges can apply to CruzHacks online



Solution
========
What I/we did to solve this problem
* Removed Apply tab from Navbar
* Updated Landing to Indicate Portal is Closed and Judge Apps are Open


Change Summary:
---------------
* Updated Landing Component
* Updated Navbar Props

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  