### PR TITLE
Adding Sticker Mule Link

### DIFF
--- a/src/Props/sponsors/partners/props.ts
+++ b/src/Props/sponsors/partners/props.ts
@@ -63,7 +63,7 @@ export const row3: PartnerProps[] = [
   },
   {
     image: stickermule,
-    url: "",
+    url: "http://hackp.ac/mlh-stickermule-hackathons",
     key: "stickermule",
   },
 ]

--- a/src/components/Partners/index.view.tsx
+++ b/src/components/Partners/index.view.tsx
@@ -14,12 +14,16 @@ const Partners: React.FC = () => {
       <div className='partners-container__rows'>
         {partnerRows.map(row => (
           <div className='partners-container__partners' key={row.key}>
-            {row.row.map(({ image, key }: PartnerProps) => (
-              <div key={key} className='partners-container__partner'>
-                {/* <a href={url} key={key} className='partners-container__partner'> */}
+            {row.row.map(({ image, url, key }: PartnerProps) => (
+              <a
+                key={key}
+                href={url}
+                rel='noreferrer'
+                target='_blank'
+                className='partners-container__partner'
+              >
                 <img src={image} alt='' className='partners-container__image' />
-                {/* </a> */}
-              </div>
+              </a>
             ))}
           </div>
         ))}

--- a/src/components/Sponsors/index.view.tsx
+++ b/src/components/Sponsors/index.view.tsx
@@ -26,16 +26,20 @@ const Sponsors: React.FC = () => {
       <div className='sponsors-container__rows'>
         {sponsorData.map(data => (
           <div className='sponsors-container__row' key={data.sponsorTier}>
-            {data.sponsors.map(({ image, key }: SponsorProps) => (
-              <div key={key} className='sponsors-container__sponsor'>
-                {/* <a href={url} key={key} className='sponsors-container__sponsor'> */}
+            {data.sponsors.map(({ image, url, key }: SponsorProps) => (
+              <a
+                key={key}
+                href={url}
+                rel='noreferrer'
+                target='_blank'
+                className='sponsors-container__sponsor'
+              >
                 <img
                   src={image}
                   alt=''
                   className='sponsors-container__sponsor-tier'
                 />
-                {/* </a> */}
-              </div>
+              </a>
             ))}
           </div>
         ))}


### PR DESCRIPTION
Problem
=======
Sticker Mule requires that the logo link is clickable for additional funding 



Solution
========
What I/we did to solve this problem
* Re-enabled a tag for sponsors and partners component
* Added new target for a href 


Change Summary:
---------------
* Updated Sponsors/Partners.tsx
* Updated Partner Props

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* We still don't have other sponsor + partner links available yet