### PR TITLE
Chore/add sponsor links

### DIFF
--- a/src/Props/sponsors/partners/props.ts
+++ b/src/Props/sponsors/partners/props.ts
@@ -63,7 +63,7 @@ export const row3: PartnerProps[] = [
   },
   {
     image: stickermule,
-    url: "",
+    url: "http://hackp.ac/mlh-stickermule-hackathons",
     key: "stickermule",
   },
 ]

--- a/src/Props/sponsors/partners/props.ts
+++ b/src/Props/sponsors/partners/props.ts
@@ -17,17 +17,17 @@ export interface PartnerProps {
 export const row1: PartnerProps[] = [
   {
     image: mlh,
-    url: "",
+    url: "https://mlh.io/",
     key: "mlh",
   },
   {
     image: woodstocks,
-    url: "",
+    url: "https://woodstockscruz.com/",
     key: "woodstocks",
   },
   {
     image: googleCloud,
-    url: "",
+    url: "https://cloud.google.com/",
     key: "googleCloud",
   },
 ]
@@ -35,17 +35,17 @@ export const row1: PartnerProps[] = [
 export const row2: PartnerProps[] = [
   {
     image: axure,
-    url: "",
+    url: "https://www.axure.com/",
     key: "axure",
   },
   {
     image: balsamiq,
-    url: "",
+    url: "https://balsamiq.com/",
     key: "balsamiq",
   },
   {
     image: wolfram,
-    url: "",
+    url: "https://www.wolfram.com/",
     key: "wolfram",
   },
 ]
@@ -53,12 +53,12 @@ export const row2: PartnerProps[] = [
 export const row3: PartnerProps[] = [
   {
     image: echo3D,
-    url: "",
+    url: "https://www.echo3d.co/",
     key: "echo3D",
   },
   {
     image: earthhacks,
-    url: "",
+    url: "https://earthhacks.io/",
     key: "earthhacks",
   },
   {

--- a/src/Props/sponsors/sponsors/props.ts
+++ b/src/Props/sponsors/sponsors/props.ts
@@ -22,17 +22,17 @@ export interface SponsorProps {
 export const kiloSponsors: SponsorProps[] = [
   {
     image: scWorks,
-    url: "",
+    url: "https://www.santacruzworks.org/",
     key: "scWorks",
   },
   {
     image: ssVentures,
-    url: "",
+    url: "https://www.linkedin.com/in/bud-colligan-1793022/",
     key: "ssVentures",
   },
   {
     image: cross,
-    url: "",
+    url: "https://cross.ucsc.edu/2022-osre/osre2022apps.html",
     key: "cross",
   },
 ]
@@ -40,22 +40,22 @@ export const kiloSponsors: SponsorProps[] = [
 export const megaSponsors: SponsorProps[] = [
   {
     image: citris,
-    url: "",
+    url: "https://citris.sites.ucsc.edu/",
     key: "citris",
   },
   {
     image: arts,
-    url: "",
+    url: "https://arts.ucsc.edu/",
     key: "arts",
   },
   {
     image: digitalNest,
-    url: "",
+    url: "https://digitalnest.org/",
     key: "digitalNest",
   },
   {
     image: progress,
-    url: "",
+    url: "https://www.progress.com/",
     key: "progress",
   },
 ]
@@ -63,12 +63,12 @@ export const megaSponsors: SponsorProps[] = [
 export const gigaSponsors: SponsorProps[] = [
   {
     image: qb3,
-    url: "",
+    url: "https://qb3.soe.ucsc.edu/",
     key: "qb3",
   },
   {
     image: baskin,
-    url: "",
+    url: "https://engineering.ucsc.edu/",
     key: "baskin",
   },
 ]
@@ -76,12 +76,12 @@ export const gigaSponsors: SponsorProps[] = [
 export const teraSponsors: SponsorProps[] = [
   {
     image: cied,
-    url: "",
+    url: "https://cied.ucsc.edu/",
     key: "cied",
   },
   {
     image: genomics,
-    url: "",
+    url: "https://genomics.ucsc.edu/",
     key: "genomics",
   },
 ]

--- a/src/components/Partners/index.view.tsx
+++ b/src/components/Partners/index.view.tsx
@@ -14,12 +14,16 @@ const Partners: React.FC = () => {
       <div className='partners-container__rows'>
         {partnerRows.map(row => (
           <div className='partners-container__partners' key={row.key}>
-            {row.row.map(({ image, key }: PartnerProps) => (
-              <div key={key} className='partners-container__partner'>
-                {/* <a href={url} key={key} className='partners-container__partner'> */}
+            {row.row.map(({ image, url, key }: PartnerProps) => (
+              <a
+                key={key}
+                href={url}
+                rel='noreferrer'
+                target='_blank'
+                className='partners-container__partner'
+              >
                 <img src={image} alt='' className='partners-container__image' />
-                {/* </a> */}
-              </div>
+              </a>
             ))}
           </div>
         ))}

--- a/src/components/Sponsors/index.view.tsx
+++ b/src/components/Sponsors/index.view.tsx
@@ -26,16 +26,20 @@ const Sponsors: React.FC = () => {
       <div className='sponsors-container__rows'>
         {sponsorData.map(data => (
           <div className='sponsors-container__row' key={data.sponsorTier}>
-            {data.sponsors.map(({ image, key }: SponsorProps) => (
-              <div key={key} className='sponsors-container__sponsor'>
-                {/* <a href={url} key={key} className='sponsors-container__sponsor'> */}
+            {data.sponsors.map(({ image, url, key }: SponsorProps) => (
+              <a
+                key={key}
+                href={url}
+                rel='noreferrer'
+                target='_blank'
+                className='sponsors-container__sponsor'
+              >
                 <img
                   src={image}
                   alt=''
                   className='sponsors-container__sponsor-tier'
                 />
-                {/* </a> */}
-              </div>
+              </a>
             ))}
           </div>
         ))}


### PR DESCRIPTION
Problem
=======
Sponsors Component need to link to sponsor's link of choice



Solution
========
What I/we did to solve this problem
* Updated sponsor's component with urls
* Changed div to a tag in sponsor's components


Change Summary:
---------------
* Updated Sponsors and Partners Props
* Updated Sponsors and Partners tsx

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images  