### PR TITLE
Fixing sizing of FAQ component

### DIFF
--- a/src/views/Home/components/FAQ/index.scss
+++ b/src/views/Home/components/FAQ/index.scss
@@ -4,9 +4,17 @@
 .faq-component {
   margin-top: -1px;
   padding-top: 40px;
+  padding-bottom: 40px;
   background-size: cover;
   background: linear-gradient(#9DD7E5, #70AACB);
+  &__questionsandanswers {
+    display: flex;
+    flex-shrink: 0;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
   &__box {
+    min-height: 1000px;
     margin: auto;
     border: 7px solid rgba(255, 255, 255, 0.75);
     border-radius: 59px;
@@ -14,9 +22,7 @@
     display: table;
     // height: 1400px;
     width: 80%;
-    @include responsiveness.screen(phone, desktop, big-desktop) {
-      width: 60%;
-    }
+    max-width: 1600px;
     @include responsiveness.screen(smallest) {
       padding: 0px;
     }
@@ -55,7 +61,7 @@
     font-family: Lato, sans-serif;
     font-style: normal;
     font-weight: normal;
-    font-size: 18px;
+    @include responsiveness.font($responsive: 4.1vw, $min: 18px, $max: 24px);
     line-height: auto;
     color: #ffffff;
     display: block;
@@ -66,13 +72,14 @@
     clear: both;
   }
   &__column {
-    vertical-align: middle;
-    float: left;
     width: 33%;
     @include responsiveness.screen(smallest, phone, tablet) {
       width: 100%;
     }
     padding-right: 2px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
   }
   &__questionsandanswersitems {
     // width: 30vh;


### PR DESCRIPTION
Problem
=======
The FAQ design is still a bit off, in terms of height, width, font-size.



Solution
========
What I/we did to solve this problem
* Added Bottom Padding to improve component spacing
* Updated min-heights, width of box component
* Updated font-sizes for question and answers


Change Summary:
---------------
* Updated FAQ scss

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] Key & Sample value to `.env` & `sample.env` 
- [ ] GCP Secret Manager (Both development and production)
- [ ] Github Secrets (Added a development and production variable)
- [ ] Github Workflows `.github/workflows/dev.yml` & `.github/workflows/prod.yml`
- [ ] webpack-config.js


Images/Important/Notes (optional):
-----------------------
# Desktop
<img width="395" alt="faq-resizing-desktop" src="https://user-images.githubusercontent.com/38510322/149437478-c9ad6768-19da-4726-92b7-5910b34ef79b.PNG">

# Mobile
<img width="407" alt="faq-resized-mobile" src="https://user-images.githubusercontent.com/38510322/149437465-2d95a31c-3c1f-4c11-8437-18de32c712e3.PNG">